### PR TITLE
Reduce bandwidth used by game state updates.

### DIFF
--- a/app/models/Games.js
+++ b/app/models/Games.js
@@ -18,6 +18,8 @@ const gameSchema = new mongoose.Schema({
   players: [{ type: ObjectId, required: true, ref: "Players" }],
   whiteCards: [{ type: ObjectId, required: true, ref: "WhiteCards" }],
   blackCards: [{ type: ObjectId, required: true, ref: "BlackCards" }],
+  blackRemaining: Number,
+  whiteRemaining: Number,
   rounds: [{ type: ObjectId, required: true, ref: "Rounds" }],
   czar: Number,
   timeLimit: Number,

--- a/app/services/game.js
+++ b/app/services/game.js
@@ -132,7 +132,7 @@ class GameService {
   async getGame(body){
     const Games = this.mongoose.model('Games');
    
-    let game = await Games.findOne({_id: body.gameID}).populate({ path: 'players', select: ['name','points','active'] }).populate('winner');
+    let game = await Games.findOne({_id: body.gameID}, '-whiteCards -blackCards').populate({ path: 'players', select: ['name','points','active'] }).populate('winner');
     
     return game;
   }
@@ -183,6 +183,7 @@ class GameService {
     
     game.rounds.push(round);
     game.blackCards = game.blackCards.filter(e => e._id !== round.blackCard);
+    game.blackRemaining = game.blackCards.length;
     
     //Count white cards we need to distribute
     let newWhiteCardCount = 0;
@@ -202,6 +203,7 @@ class GameService {
     //newWhiteCards is now all the cards we will give back to players
     //possibleWhiteCards is all the remaining whitecards in the deck
     game.whiteCards = possibleWhiteCards.filter(wc => !newWhiteCards.some(nwc => nwc == wc));
+    game.whiteRemaining = game.whiteCards.length;
     game = await game.save();
 
     //Give each player (handSize) white cards
@@ -217,7 +219,7 @@ class GameService {
     
     round = Rounds.findOne({_id: round._id})
                     .populate({ path: 'players', select: ['name','points','active'] })
-                    .populate('game').populate({
+                    .populate('game', '-whiteCards -blackCards').populate({
                       path: 'blackCard',
                       populate: {
                         path: 'set',
@@ -402,12 +404,13 @@ class GameService {
   }
 
   //games/getLatestRound
+  whiteRemaining;
   async getLatestRound (body){
     const Rounds = this.mongoose.model('Rounds');
     const Games = this.mongoose.model('Games');
     const Players = this.mongoose.model('Players');
-    let game = await Games.findOne({_id: body.gameID}).populate('winner');
-    
+    let game = await Games.findOne({_id: body.gameID}, '-whiteCards -blackCards').populate('winner');
+
     let latestRoundId = game.rounds[game.rounds.length - 1];
     
     //Need to figure out a way to include candidateCards here


### PR DESCRIPTION
Remove full transmission of complete card set with every tick and update. The full card sets are not used by the client, except to obtain the remaining card counts. Add remaining black and white card fields to the Game model, as well as associated update mechanism.
Note: There may be a cleaner way to do this beyond storing metadata in the model, but I couldn't figure it out.